### PR TITLE
(WIP) Vagrant development environment with Ansible - Do Not Merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out.bin
 out.elf
 temp.bin
 *.o
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,13 +50,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Don't boot with headless mode
-  #   vb.gui = true
-  #
-  #   # Use VBoxManage to customize the VM. For example to change memory:
-  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
-  # end
+  config.vm.provider "virtualbox" do |vb|
+    # Don't boot with headless mode
+    # vb.gui = true
+
+    # Use VBoxManage to customize the VM. For example to change memory:
+    vb.customize ["modifyvm", :id, "--memory", "2048"]
+    vb.cpus = 2
+  end
   #
   # View the documentation for the provider you're using for more
   # information on available options.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,127 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "provision/ansible-dev.yml"
+  end
+  # config.vm.provision "shell", path: "provision.sh"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.100"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with CFEngine. CFEngine Community packages are
+  # automatically installed. For example, configure the host as a
+  # policy server and optionally a policy file to run:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.am_policy_hub = true
+  #   # cf.run_file = "motd.cf"
+  # end
+  #
+  # You can also configure and bootstrap a client to an existing
+  # policy server:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.policy_server_address = "10.0.2.15"
+  # end
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file default.pp in the manifests_path directory.
+  #
+  # config.vm.provision "puppet" do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "default.pp"
+  # end
+
+  # Enable provisioning with chef solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.cookbooks_path = "../my-recipes/cookbooks"
+  #   chef.roles_path = "../my-recipes/roles"
+  #   chef.data_bags_path = "../my-recipes/data_bags"
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { mysql_password: "foo" }
+  # end
+
+  # Enable provisioning with chef server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Opscode Platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision "chef_client" do |chef|
+  #   chef.chef_server_url = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Opscode platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+end

--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -11,6 +11,7 @@
       - unzip
       - texinfo
     gendev_dir: /opt/gendev
+    vagrant_dir: /vagrant
     vagrant_user: vagrant
     vagrant_group: vagrant
   tasks:
@@ -46,3 +47,8 @@
       shell: >
         chdir={{ gendev_dir }}/sgdk
         . ~/.gendev; make install
+
+    - name: Build game
+      shell: >
+        chdir={{ vagrant_dir }}
+        . ~/.gendev; make

--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -2,9 +2,17 @@
 - hosts: all
   vars:
     apt_packages:
+      - htop
       - emacs24-nox
       - vim-nox
       - build-essential
+      - git
+      - subversion
+      - unzip
+      - texinfo
+    gendev_dir: /opt/gendev
+    vagrant_user: vagrant
+    vagrant_group: vagrant
   tasks:
     - name: Install debian packages
       sudo: yes
@@ -16,3 +24,25 @@
         creates=~/.ansible-profile
         cat /vagrant/provision/vagrant_env >> ~/.profile;
         touch ~/.ansible-profile
+
+    - name: Checkout the latest gendev
+      sudo: yes
+      subversion: >
+        repo=http://gendev.googlecode.com/svn/trunk/
+        dest={{ gendev_dir }}
+
+    - name: Permission gendev directory
+      sudo: yes
+      file: >
+        path={{ gendev_dir }} state=directory recurse=yes
+        owner={{ vagrant_user }} group={{ vagrant_group }}
+
+    - name: Build gendev
+      shell: >
+        chdir={{ gendev_dir }}
+        make
+
+    - name: Build sgdk
+      shell: >
+        chdir={{ gendev_dir }}/sgdk
+        . ~/.gendev; make install

--- a/provision/ansible-dev.yml
+++ b/provision/ansible-dev.yml
@@ -1,0 +1,18 @@
+---
+- hosts: all
+  vars:
+    apt_packages:
+      - emacs24-nox
+      - vim-nox
+      - build-essential
+  tasks:
+    - name: Install debian packages
+      sudo: yes
+      apt: name={{ item }} update_cache=yes
+      with_items: apt_packages
+
+    - name: Overwrite profile
+      shell: >
+        creates=~/.ansible-profile
+        cat /vagrant/provision/vagrant_env >> ~/.profile;
+        touch ~/.ansible-profile

--- a/provision/vagrant_env
+++ b/provision/vagrant_env
@@ -1,0 +1,1 @@
+cd /vagrant

--- a/provision/vagrant_env
+++ b/provision/vagrant_env
@@ -1,1 +1,6 @@
+if [ -f ~/.gendev ]
+then
+    . ~/.gendev
+fi
+
 cd /vagrant


### PR DESCRIPTION
This allows for standing up a ready development environment with one command: `vagrant up`
- [x] Checkout and compile the latest `gendev`
- [x] Compile `sgdk` using `gendev`
- [ ] Compile `cave-story-md` using `sgdk`
- [x] Able to compile immediately after `vagrant ssh` login; i.e. just running `make` works
- [ ] Don't recompile `gendev` or `sgdk` when running `vagrant provision` if they're already on the system
### Host dependencies
- Vagrant: `sudo pacman -S vagrant`; `sudo apt-get install vagrant`
- Ansible: `sudo pacman -S ansible`; `sudo apt-get install ansible`
