### PR TITLE
docs: fix simple typo, futher -> further

### DIFF
--- a/tools/xgmtool/src/vgm.c
+++ b/tools/xgmtool/src/vgm.c
@@ -748,7 +748,7 @@ static LList* VGM_extractSampleFromSeek(VGM* vgm, LList* command, bool convert)
             // delta >= 20 means rate < 2200 Hz --> very unlikely, discard it from mean computation
             if (delta < 20)
             {
-                // compute delta mean for futher correction
+                // compute delta mean for further correction
                 if (deltaMean == 0) deltaMean = delta;
                 else deltaMean = (delta * 0.1) + (deltaMean * 0.9);
             }


### PR DESCRIPTION
There is a small typo in tools/xgmtool/src/vgm.c.

Should read `further` rather than `futher`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md