### PR TITLE
Fix camera.x/yshifted using wrong values

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -126,9 +126,6 @@ void camera_update() {
 		if((x_next & 0xF000) == ((x_next + x_shake) & 0xF000)) x_next += x_shake;
 		if((y_next & 0xF000) == ((y_next + y_shake) & 0xF000)) y_next += y_shake;
 	}
-	// Shifted values
-	camera.x_shifted = (x_next >> CSF) - SCREEN_HALF_W;
-	camera.y_shifted = (y_next >> CSF) - SCREEN_HALF_H;
 	// Update quick fetch cutoff values
 	camera_xmin = camera.x - pixel_to_sub(SCREEN_HALF_W + 32);
 	camera_xsize = pixel_to_sub(SCREEN_WIDTH + 64);
@@ -200,4 +197,7 @@ void camera_update() {
 	// Apply camera position
 	camera.x = x_next;
 	camera.y = y_next;
+	// Shifted values
+	camera.x_shifted = (x_next >> CSF) - SCREEN_HALF_W;
+	camera.y_shifted = (y_next >> CSF) - SCREEN_HALF_H;
 }


### PR DESCRIPTION
x_shifted and y_shifted are set before the diagonal tilemap update to x and y_next. This fixes #343 (been in the game for a long time!).

🅱️efore:
https://user-images.githubusercontent.com/7954485/195723257-02168f2c-d318-459e-9226-133b0518c1cf.mp4

after:
https://user-images.githubusercontent.com/7954485/195723317-a90e83e1-3c22-494b-9d40-8268e0bbb408.mp4

[doukutsu-en-camerashift.zip](https://github.com/andwn/cave-story-md/files/9781058/doukutsu-en-camerashift.zip)
