### PR TITLE
Fix spur being ridiculously overpowered

### DIFF
--- a/src/entity.c
+++ b/src/entity.c
@@ -186,7 +186,8 @@ void entities_update(uint8_t draw) {
 			};
 			uint8_t cont = FALSE;
 			for(uint16_t i = 0; i < MAX_BULLETS; i++) {
-				if(playerBullet[i].extent.x2 >= ee.x1 &&
+				if(playerBullet[i].ttl &&
+					playerBullet[i].extent.x2 >= ee.x1 &&
                     playerBullet[i].extent.x1 <= ee.x2 &&
                     playerBullet[i].extent.y2 >= ee.y1 &&
 					playerBullet[i].extent.y1 <= ee.y2)

--- a/src/hud.c
+++ b/src/hud.c
@@ -185,9 +185,16 @@ void hud_refresh_energy(uint8_t hard) {
     uint8_t tempMaxEnergy;
     uint8_t tempEnergy;
 	if(playerWeapon[currentWeapon].type == WEAPON_SPUR) {
-		hudMaxEnergy = spur_time[pal_mode||cfg_60fps][playerWeapon[currentWeapon].level];
-        tempMaxEnergy = hudMaxEnergy >> 1;
-        tempEnergy = hudEnergy >> 1;
+		hudMaxEnergy = spur_time[pal_mode][playerWeapon[currentWeapon].level];
+		if(playerWeapon[currentWeapon].level == 3){
+			tempMaxEnergy = hudMaxEnergy >> 2;
+        	tempEnergy = hudEnergy >> 2;
+		} else
+		{
+        	tempMaxEnergy = hudMaxEnergy >> 1;
+        	tempEnergy = hudEnergy >> 1;
+		}
+
         if(hudEnergy != playerWeapon[currentWeapon].energy) hudMaxBlink = 1;
 	} else {
 		hudMaxEnergy = max(weapon_info[playerWeapon[currentWeapon].type].experience[hudLevel-1], 10);

--- a/src/hud.c
+++ b/src/hud.c
@@ -185,7 +185,7 @@ void hud_refresh_energy(uint8_t hard) {
     uint8_t tempMaxEnergy;
     uint8_t tempEnergy;
 	if(playerWeapon[currentWeapon].type == WEAPON_SPUR) {
-		hudMaxEnergy = spur_time[pal_mode][playerWeapon[currentWeapon].level];
+		hudMaxEnergy = spur_time[pal_mode||cfg_60fps][playerWeapon[currentWeapon].level];
 		if(playerWeapon[currentWeapon].level == 3){
 			tempMaxEnergy = hudMaxEnergy >> 2;
         	tempEnergy = hudEnergy >> 2;

--- a/src/player.c
+++ b/src/player.c
@@ -30,8 +30,8 @@
 })
 
 const uint8_t spur_time[2][4] = {
-	{ 0, 60, 90, 120 }, // NTSC
-	{ 0, 50, 75, 100 }, // PAL
+	{ 0, 40, 60, 200 }, // NTSC
+	{ 0, 33, 50, 166 }, // PAL
 };
 
 VDPSprite weaponSprite;
@@ -395,7 +395,7 @@ void player_update() {
 			weapon_fire(*w);
 			shoot_cooldown = 4;
 		} else if(joystate & btn[cfg_btn_shoot]) {
-			uint8_t maxenergy = spur_time[pal_mode||cfg_60fps][w->level];
+			uint8_t maxenergy = spur_time[pal_mode][w->level];
 			if(!(w->level == 3 && w->energy == maxenergy)) {
 				w->energy += (playerEquipment & EQUIP_TURBOCHARGE) ? 3 : 2;
 				if(w->energy >= maxenergy) {
@@ -416,7 +416,7 @@ void player_update() {
 		} else {
 			if(mgun_chargetime) {
 				if(w->level > 1) {
-					if(w->energy == spur_time[pal_mode||cfg_60fps][3]) w->level = 4;
+					if(w->energy == spur_time[pal_mode][3]) w->level = 4;
 					weapon_fire(*w);
 				}
 				mgun_chargetime = 0;

--- a/src/player.c
+++ b/src/player.c
@@ -395,7 +395,7 @@ void player_update() {
 			weapon_fire(*w);
 			shoot_cooldown = 4;
 		} else if(joystate & btn[cfg_btn_shoot]) {
-			uint8_t maxenergy = spur_time[pal_mode][w->level];
+			uint8_t maxenergy = spur_time[pal_mode||cfg_60fps][w->level];
 			if(!(w->level == 3 && w->energy == maxenergy)) {
 				w->energy += (playerEquipment & EQUIP_TURBOCHARGE) ? 3 : 2;
 				if(w->energy >= maxenergy) {
@@ -416,7 +416,7 @@ void player_update() {
 		} else {
 			if(mgun_chargetime) {
 				if(w->level > 1) {
-					if(w->energy == spur_time[pal_mode][3]) w->level = 4;
+					if(w->energy == spur_time[pal_mode||cfg_60fps][3]) w->level = 4;
 					weapon_fire(*w);
 				}
 				mgun_chargetime = 0;

--- a/src/weapon.c
+++ b/src/weapon.c
@@ -1086,7 +1086,7 @@ void bullet_update_spur(Bullet *b) {
 				t->type = WEAPON_SPUR_TAIL;
 				t->level = b->level;
 				t->sheet = b->sheet;
-				t->damage = (t->level << 2) - 1;
+				t->damage = t->level + 1;
 				t->ttl = TIME_8(20);
 				t->dir = b->dir;
 				t->x = pixel_to_sub(spur_xmark);


### PR DESCRIPTION
As it is, the Spur does like 4x as much damage and (on 60fps at least) twice as fast to charge.
This needs to be stopped. I couldn't figure out why it was doing so much DPS because all of the numbers look right, so i just lazily reduced the trail damage. 

Comparison on CSE2 and MD 0.8

https://user-images.githubusercontent.com/7954485/196330146-6c7128a8-bcdc-4c28-a9b4-5065d723c804.mp4

Fix

https://user-images.githubusercontent.com/7954485/196330284-327c9b51-4197-4b31-b250-cb06db92fe6e.mp4

[doukutsu-en-spur.zip](https://github.com/andwn/cave-story-md/files/9806268/doukutsu-en-spur.zip)
